### PR TITLE
Fix monthly schedule always asking for Monday

### DIFF
--- a/VenueControl/VenueAuthoring/PropertyEntrySessionStates/ScheduleEntry/MonthlyCommencementEntryState.cs
+++ b/VenueControl/VenueAuthoring/PropertyEntrySessionStates/ScheduleEntry/MonthlyCommencementEntryState.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord;
-using FFXIVVenues.Veni.Authorisation;
 using FFXIVVenues.Veni.Infrastructure.Context;
 using FFXIVVenues.Veni.Infrastructure.Context.SessionHandling;
 using FFXIVVenues.Veni.Utils;
@@ -32,7 +30,7 @@ class MonthlyCommencementEntryState : ISessionState
         // Assumes that there is not multiple schedules for the same day with differing times/location
         if (this._currentDay == null)
         {
-            this._currentDay = c.Session.GetItem<Day>(SessionKeys.NOW_SETTING_DAY);
+            this._currentDay = c.Session.GetItem<Day?>(SessionKeys.NOW_SETTING_DAY);
             c.Session.ClearItem(SessionKeys.NOW_SETTING_DAY);
         }
         this._currentDay ??= this._schedules.First()!.Key;


### PR DESCRIPTION
When creating a venue with a monthly schedule, if you indicated that your days were something other than Monday (like Wednesfay and Friday), Veni would first ask you for Monday anyway. 

This is enough to cause Veni to error when it tries going to the next day and stall (couldn't find the day in your schedule you were on). 

This is due to the casting of the `GetItem` call, I had set it to `Day` not `Day?`. When the given key is not present in the session, it will return default. For nullable items this is `null` but for enums it'll be `0` or here... "Monday". I failed to notice I put in the enum type directly and not the nullable variant here, causing the first `_currentDay` to always be set to `Monday`.

This resolves that. 